### PR TITLE
Add build consistency check workflow

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -1,0 +1,18 @@
+name: "Validate build consistency"
+on:
+  pull_request:
+
+jobs:
+  check-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm ci
+      - name: Rebuild project
+        run: npm run build
+      - name: Verify build output is committed
+        run: git diff --exit-code build/index.js


### PR DESCRIPTION
## Summary
- add a workflow that verifies `npm run build` doesn't change `build/index.js`
- restore previous build output after pre-commit hook changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848c4c8b33c832c909719eb41b6094d